### PR TITLE
Any link `config.select` should be null when unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 0.4.1 - 2021-09-02
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- [#6](https://github.com/netglue/prismic-cli/pull/6) adds config.select = null to links that do not have to be a specific type to match the structure returned from the api. This helps to reduce noise in diffs…
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 0.4.0 - 2021-09-02
 
 ### Added

--- a/src/TypeBuilder.php
+++ b/src/TypeBuilder.php
@@ -111,15 +111,9 @@ final class TypeBuilder
             'select' => 'document',
             'label' => $label,
             'placeholder' => $placeholder,
+            'customtypes' => $customTypes,
+            'tags' => $tags,
         ]);
-
-        if (! empty($customTypes)) {
-            $config['customtypes'] = $customTypes;
-        }
-
-        if (! empty($tags)) {
-            $config['tags'] = $tags;
-        }
 
         return [
             'type' => self::TYPE_LINK,
@@ -136,6 +130,8 @@ final class TypeBuilder
             'allowTargetBlank' => $allowTargetBlank ? true : null,
             'customtypes' => empty($customTypes) ? null : $customTypes,
         ]);
+
+        $config['select'] = null;
 
         return [
             'type' => self::TYPE_LINK,

--- a/test/Unit/TypeBuilderTest.php
+++ b/test/Unit/TypeBuilderTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PrimoTest\Cli\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Primo\Cli\TypeBuilder as T;
+
+class TypeBuilderTest extends TestCase
+{
+    public function testLinkConfigHasExpectedStructure(): void
+    {
+        $data = T::link('Label', 'Placeholder', false, null);
+        $expect = [
+            'type' => T::TYPE_LINK,
+            'config' => [
+                'select' => null,
+                'label' => 'Label',
+                'placeholder' => 'Placeholder',
+            ],
+        ];
+        self::assertEquals($expect, $data);
+    }
+}


### PR DESCRIPTION
This adds config.select = null to links that do not have to be a specific type to match the structure returned from the api. This helps to reduce noise in diffs.