### PR TITLE
Make sure optional tools are optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 0.4.2 - 2021-09-02
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- Nothing.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- [#7](https://github.com/netglue/prismic-cli/pull/7) makes sure that dependencies are loadable when the user opts out of the custom type api tooling.
+
 ## 0.4.1 - 2021-09-02
 
 ### Added

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -44,6 +44,7 @@ final class ConfigProvider
         return [
             'factories' => [
                 Console\BuildCommand::class => Console\Container\BuildCommandFactory::class,
+                Type\LocalPersistence::class => Type\Container\LocalPersistenceFactory::class,
                 BuildConfig::class => Container\BuildConfigFactory::class,
             ],
         ];

--- a/src/CustomTypeApiConfigProvider.php
+++ b/src/CustomTypeApiConfigProvider.php
@@ -39,7 +39,6 @@ final class CustomTypeApiConfigProvider
                 Console\DownloadCommand::class => Console\Container\DownloadCommandFactory::class,
                 Console\UploadCommand::class => Console\Container\UploadCommandFactory::class,
 
-                Type\LocalPersistence::class => Type\Container\LocalPersistenceFactory::class,
                 Type\RemotePersistence::class => Type\Container\RemotePersistenceFactory::class,
 
                 DiffTool::class => Container\DiffToolFactory::class,


### PR DESCRIPTION
Fixes an issue where local storage dependencies were declared in the config provider for custom type api usage but required during general build operations.
Adds test to make sure all deps can be loaded with various config provider combinations and moves dependency config to the correct provider