### PR TITLE
Fix number fragments cannot configure zero

### DIFF
--- a/src/TypeBuilder.php
+++ b/src/TypeBuilder.php
@@ -241,7 +241,7 @@ final class TypeBuilder
                 'placeholder' => self::nullifyString($placeholder),
                 'min' => $min,
                 'max' => $max,
-            ]),
+            ], [self::class, 'filterNull']),
         ];
     }
 
@@ -437,5 +437,15 @@ final class TypeBuilder
                 'choices' => $slices,
             ]),
         ];
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @psalm-assert !null $value
+     */
+    private static function filterNull($value): bool
+    {
+        return $value !== null;
     }
 }

--- a/test/Unit/TypeBuilderTest.php
+++ b/test/Unit/TypeBuilderTest.php
@@ -22,4 +22,19 @@ class TypeBuilderTest extends TestCase
         ];
         self::assertEquals($expect, $data);
     }
+
+    public function testThatNumbersWillIncludeTheMinWhenZero(): void
+    {
+        $data = T::number('Number', 'Placeholder', 0, 100);
+        $expect = [
+            'type' => T::TYPE_NUMBER,
+            'config' => [
+                'label' => 'Number',
+                'placeholder' => 'Placeholder',
+                'min' => 0,
+                'max' => 100,
+            ],
+        ];
+        self::assertEquals($expect, $data);
+    }
 }


### PR DESCRIPTION
Because of how the default filter for array_filter works, values with integer zero were incorrectly removed from the 'min' or 'max' value for a number.