### PR TITLE
Add CI config for Laminas Matrix Action

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,0 +1,8 @@
+{
+    "ignore_php_platform_requirements": {
+        "7.4": false,
+        "8.0": false,
+        "8.1": false,
+        "8.2": true
+    }
+}


### PR DESCRIPTION
Platform requirements on v8.0 are being ignored therefore failing 8.0 on highest.