### PR TITLE
Implement Shared Slice Management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ phpunit.xml
 /vendor/
 /example/dist/*
 !/example/dist/.gitkeep
+/example/slices/dist/*
+!/example/slices/dist/.gitkeep

--- a/example/example.php
+++ b/example/example.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use Primo\Cli\BuildConfig;
 use Primo\Cli\Console\BuildCommand;
+use Primo\Cli\Slice\LocalPersistence as SlicePersistence;
+use Primo\Cli\Slice\SliceBuildConfig;
 use Primo\Cli\Type\LocalPersistence;
 use Symfony\Component\Console\Application;
 
@@ -66,7 +68,7 @@ $types = [
 ];
 
 /**
- * Define the Source and destination directories.
+ * Define the Source and destination directories for the document types
  *
  * Source contains php source files and the dist directory is the target directory for Json
  */
@@ -78,7 +80,21 @@ $dist = __DIR__ . '/dist';
  */
 $config = BuildConfig::withArraySpecs($source, $dist, $types);
 
+/**
+ * Source and dist dirs for shared slices
+ */
+
+$source = __DIR__ . '/slices/source';
+$dist = __DIR__ . '/slices/dist';
+
+$sliceConfig = SliceBuildConfig::withDirectories($source, $dist);
+
 $application = new Application('Primo Builder Example');
-$application->add(new BuildCommand($config, new LocalPersistence($config)));
+$application->add(new BuildCommand(
+    $config,
+    new LocalPersistence($config),
+    $sliceConfig,
+    new SlicePersistence($sliceConfig),
+));
 
 return $application->run();

--- a/example/slices/source/banner-header.php
+++ b/example/slices/source/banner-header.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Primo\Cli\TypeBuilder as T;
+
+return T::sharedSlice(
+    'banner-header',
+    'Banner Header Photo',
+    'A full-width header photo with caption',
+    [
+        T::sharedSliceVariation(
+            'default',
+            'Default Style',
+            '1',
+            'The default banner style',
+            [
+                'heading' => T::richText('Main heading', null, [T::H1], false),
+                'photo' => T::img('Image', null, 1600, 900, [
+                    T::imgView('portrait', 600, 800),
+                    T::imgView('square', 600, 600),
+                ]),
+                'text' => T::richText('Additional content', null, [T::P, T::A, T::B, T::I], true),
+            ],
+        ),
+    ],
+);

--- a/example/source/partial/standard-slices.php
+++ b/example/source/partial/standard-slices.php
@@ -25,6 +25,15 @@ return T::sliceZone('Document Body', [
         'caption' => T::richText('Caption Text', 'Say something', ['paragraph', 'em', 'strong'], false),
     ]),
     'body-text' => T::richText('Standard Prose', null, T::blocksAll(), true, true),
+    /**
+     * It's up to you to add possible shared slices to your types, and, also match up the key "banner-header" to an
+     * actual shared slice.
+     *
+     * Each item should be 'slice-id' => ['type' => T::TYPE_SHARED_SLICE]
+     */
+    'banner-header' => [
+        'type' => T::TYPE_SHARED_SLICE,
+    ],
 ], [
     'carousel' => [
         T::sliceLabel('dark-mode', 'Dark Styling'),

--- a/example/upload-download.php
+++ b/example/upload-download.php
@@ -13,10 +13,16 @@ use Http\Discovery\Psr17FactoryDiscovery;
 use Http\Discovery\Psr18ClientDiscovery;
 use Primo\Cli\BuildConfig;
 use Primo\Cli\Console\ConsoleColourDiffFormatter;
+use Primo\Cli\Console\DeleteCommand;
+use Primo\Cli\Console\DeleteSliceCommand;
 use Primo\Cli\Console\DiffCommand;
 use Primo\Cli\Console\DownloadCommand;
+use Primo\Cli\Console\DownloadSlicesCommand;
+use Primo\Cli\Console\ListSlicesCommand;
 use Primo\Cli\Console\UploadCommand;
+use Primo\Cli\Console\UploadSlicesCommand;
 use Primo\Cli\DiffTool;
+use Primo\Cli\Slice\SliceBuildConfig;
 use Primo\Cli\Type\LocalPersistence;
 use Primo\Cli\Type\RemotePersistence;
 use Prismic\DocumentType\BaseClient;
@@ -83,9 +89,22 @@ $config = BuildConfig::withArraySpecs($source, $dist, $types);
 $localStorage = new LocalPersistence($config);
 $remoteStorage = new RemotePersistence($client);
 
+$sliceConfig = SliceBuildConfig::withDirectories(
+    __DIR__ . '/slices/source',
+    __DIR__ . '/slices/dist',
+);
+
+$localSlices = new \Primo\Cli\Slice\LocalPersistence($sliceConfig);
+$remoteSlices = new \Primo\Cli\Slice\RemotePersistence($client);
+
 $application = new Application('Primo Upload and Download Example');
+$application->add(new DeleteCommand($client));
+$application->add(new DeleteSliceCommand($client));
 $application->add(new DownloadCommand($localStorage, $remoteStorage));
+$application->add(new DownloadSlicesCommand($localSlices, $remoteSlices));
+$application->add(new ListSlicesCommand($client));
 $application->add(new UploadCommand($localStorage, $remoteStorage));
+$application->add(new UploadSlicesCommand($localSlices, $remoteSlices));
 $application->add(new DiffCommand(
     new DiffTool(new Differ(new UnifiedDiffOutputBuilder())),
     new ConsoleColourDiffFormatter(),

--- a/example/upload-download.php
+++ b/example/upload-download.php
@@ -21,6 +21,7 @@ use Primo\Cli\Type\LocalPersistence;
 use Primo\Cli\Type\RemotePersistence;
 use Prismic\DocumentType\BaseClient;
 use SebastianBergmann\Diff\Differ;
+use SebastianBergmann\Diff\Output\UnifiedDiffOutputBuilder;
 use Symfony\Component\Console\Application;
 
 $repo = getenv('PRISMIC_REPOSITORY');
@@ -86,7 +87,7 @@ $application = new Application('Primo Upload and Download Example');
 $application->add(new DownloadCommand($localStorage, $remoteStorage));
 $application->add(new UploadCommand($localStorage, $remoteStorage));
 $application->add(new DiffCommand(
-    new DiffTool(new Differ()),
+    new DiffTool(new Differ(new UnifiedDiffOutputBuilder())),
     new ConsoleColourDiffFormatter(),
     $localStorage,
     $remoteStorage,

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -23,6 +23,10 @@ final class ConfigProvider
                         'source' => null, // Path to directory containing 1 php file per type
                         'dist' => null, // Path to directory to store JSON output files
                     ],
+                    'slices' => [
+                        'source' => null, // Path to directory containing 1 PHP file per Shared Slice
+                        'dist' => null, // Output directory for built slices
+                    ],
                 ],
                 /**
                  * Types should look something like this:
@@ -44,6 +48,8 @@ final class ConfigProvider
         return [
             'factories' => [
                 Console\BuildCommand::class => Console\Container\BuildCommandFactory::class,
+                Slice\SliceBuildConfig::class => Slice\Container\SliceBuildConfigFactory::class,
+                Slice\LocalPersistence::class => Slice\Container\LocalPersistenceFactory::class,
                 Type\LocalPersistence::class => Type\Container\LocalPersistenceFactory::class,
                 BuildConfig::class => Container\BuildConfigFactory::class,
             ],

--- a/src/Console/BuildCommand.php
+++ b/src/Console/BuildCommand.php
@@ -6,9 +6,13 @@ namespace Primo\Cli\Console;
 
 use Primo\Cli\BuildConfig;
 use Primo\Cli\Exception\BuildError;
+use Primo\Cli\Slice\BuildSpec;
+use Primo\Cli\Slice\SliceBuildConfig;
+use Primo\Cli\Slice\SlicePersistence;
 use Primo\Cli\Type\Spec;
 use Primo\Cli\Type\TypePersistence;
 use Prismic\DocumentType\Definition;
+use Prismic\DocumentType\SharedSlice;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -32,6 +36,8 @@ final class BuildCommand extends Command
     public function __construct(
         private BuildConfig $config,
         private TypePersistence $localStorage,
+        private SliceBuildConfig $sliceConfig,
+        private SlicePersistence $sliceStorage,
         string $name = self::DEFAULT_NAME,
     ) {
         parent::__construct($name);
@@ -51,22 +57,33 @@ final class BuildCommand extends Command
     {
         $style = new SymfonyStyle($input, $output);
         $types = $this->config->types();
-        $style->progressStart(count($types) + 1);
-        foreach ($this->config->types() as $spec) {
-            $this->buildType($spec);
-            $style->progressAdvance(1);
-        }
+        $slices = $this->sliceConfig->slices();
+        $style->progressStart(count($types) + count($slices) + 1);
+
+        $this->buildTypes($types, $style);
+        $this->buildSlices($slices, $style);
 
         $this->localStorage->writeIndex($types);
         $style->progressAdvance(1);
+
         $style->progressFinish();
 
         $style->success(sprintf(
-            '%d document types processed',
+            '%d document types and %d shared slices processed',
             count($types),
+            count($slices),
         ));
 
         return self::SUCCESS;
+    }
+
+    /** @param array<array-key, Spec> $types */
+    private function buildTypes(array $types, SymfonyStyle $style): void
+    {
+        foreach ($types as $spec) {
+            $this->buildType($spec);
+            $style->progressAdvance(1);
+        }
     }
 
     private function buildType(Spec $type): void
@@ -97,5 +114,36 @@ final class BuildCommand extends Command
             true,
             $content,
         ));
+    }
+
+    /** @param list<BuildSpec> $slices */
+    private function buildSlices(array $slices, SymfonyStyle $style): void
+    {
+        foreach ($slices as $spec) {
+            $this->buildSlice($spec);
+            $style->progressAdvance(1);
+        }
+    }
+
+    private function buildSlice(BuildSpec $spec): void
+    {
+        try {
+            /** @psalm-suppress UnresolvableInclude */
+            $data = require $spec->source;
+        } catch (Throwable $e) {
+            throw BuildError::unknown($e);
+        }
+
+        if (! is_array($data)) {
+            throw BuildError::invalidSliceSpec($spec);
+        }
+
+        try {
+            $content = json_encode($data, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT);
+        } catch (Throwable $error) {
+            throw BuildError::unknown($error);
+        }
+
+        $this->sliceStorage->write(SharedSlice::new($spec->id, $content));
     }
 }

--- a/src/Console/Container/BuildCommandFactory.php
+++ b/src/Console/Container/BuildCommandFactory.php
@@ -6,6 +6,8 @@ namespace Primo\Cli\Console\Container;
 
 use Primo\Cli\BuildConfig;
 use Primo\Cli\Console\BuildCommand;
+use Primo\Cli\Slice\LocalPersistence as LocalSlicePersistence;
+use Primo\Cli\Slice\SliceBuildConfig;
 use Primo\Cli\Type\LocalPersistence;
 use Psr\Container\ContainerInterface;
 
@@ -16,6 +18,8 @@ final class BuildCommandFactory
         return new BuildCommand(
             $container->get(BuildConfig::class),
             $container->get(LocalPersistence::class),
+            $container->get(SliceBuildConfig::class),
+            $container->get(LocalSlicePersistence::class),
         );
     }
 }

--- a/src/Console/Container/DeleteCommandFactory.php
+++ b/src/Console/Container/DeleteCommandFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primo\Cli\Console\Container;
+
+use Primo\Cli\Console\DeleteCommand;
+use Prismic\DocumentType\Client;
+use Psr\Container\ContainerInterface;
+
+final class DeleteCommandFactory
+{
+    public function __invoke(ContainerInterface $container): DeleteCommand
+    {
+        return new DeleteCommand(
+            $container->get(Client::class),
+        );
+    }
+}

--- a/src/Console/Container/DeleteSliceCommandFactory.php
+++ b/src/Console/Container/DeleteSliceCommandFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primo\Cli\Console\Container;
+
+use Primo\Cli\Console\DeleteSliceCommand;
+use Prismic\DocumentType\Client;
+use Prismic\DocumentType\SharedSliceManagementClient;
+use Psr\Container\ContainerInterface;
+use RuntimeException;
+
+final class DeleteSliceCommandFactory
+{
+    public function __invoke(ContainerInterface $container): DeleteSliceCommand
+    {
+        $client = $container->get(Client::class);
+        if (! $client instanceof SharedSliceManagementClient) {
+            throw new RuntimeException('Ensure that the doctype client version is >= 1.5.0');
+        }
+
+        return new DeleteSliceCommand(
+            $client,
+        );
+    }
+}

--- a/src/Console/Container/DownloadSlicesCommandFactory.php
+++ b/src/Console/Container/DownloadSlicesCommandFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primo\Cli\Console\Container;
+
+use Primo\Cli\Console\DownloadSlicesCommand;
+use Primo\Cli\Slice\LocalPersistence;
+use Primo\Cli\Slice\RemotePersistence;
+use Psr\Container\ContainerInterface;
+
+final class DownloadSlicesCommandFactory
+{
+    public function __invoke(ContainerInterface $container): DownloadSlicesCommand
+    {
+        return new DownloadSlicesCommand(
+            $container->get(LocalPersistence::class),
+            $container->get(RemotePersistence::class),
+        );
+    }
+}

--- a/src/Console/Container/ListSlicesCommandFactory.php
+++ b/src/Console/Container/ListSlicesCommandFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primo\Cli\Console\Container;
+
+use Primo\Cli\Console\ListSlicesCommand;
+use Prismic\DocumentType\Client;
+use Prismic\DocumentType\SharedSliceManagementClient;
+use Psr\Container\ContainerInterface;
+use RuntimeException;
+
+final class ListSlicesCommandFactory
+{
+    public function __invoke(ContainerInterface $container): ListSlicesCommand
+    {
+        $client = $container->get(Client::class);
+        if (! $client instanceof SharedSliceManagementClient) {
+            throw new RuntimeException('Ensure that the doctype client version is >= 1.5.0');
+        }
+
+        return new ListSlicesCommand(
+            $client,
+        );
+    }
+}

--- a/src/Console/Container/UploadSlicesCommandFactory.php
+++ b/src/Console/Container/UploadSlicesCommandFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primo\Cli\Console\Container;
+
+use Primo\Cli\Console\UploadSlicesCommand;
+use Primo\Cli\Slice\LocalPersistence;
+use Primo\Cli\Slice\RemotePersistence;
+use Psr\Container\ContainerInterface;
+
+final class UploadSlicesCommandFactory
+{
+    public function __invoke(ContainerInterface $container): UploadSlicesCommand
+    {
+        return new UploadSlicesCommand(
+            $container->get(LocalPersistence::class),
+            $container->get(RemotePersistence::class),
+        );
+    }
+}

--- a/src/Console/DeleteCommand.php
+++ b/src/Console/DeleteCommand.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primo\Cli\Console;
+
+use Primo\Cli\Assert;
+use Prismic\DocumentType\Client;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Throwable;
+
+use function sprintf;
+
+#[AsCommand('primo:types:delete')]
+final class DeleteCommand extends Command
+{
+    public const DEFAULT_NAME = 'primo:types:delete';
+
+    public function __construct(private readonly Client $apiClient, string $name = self::DEFAULT_NAME)
+    {
+        parent::__construct($name);
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription(
+            'This command deletes a single document type. ',
+        );
+        $this->addArgument(
+            'type',
+            InputArgument::REQUIRED,
+            'The document type to delete',
+        );
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $style = new SymfonyStyle($input, $output);
+        $type = $input->getArgument('type');
+        Assert::nullOrStringNotEmpty($type);
+
+        if ($type === null) {
+            $style->error('The type to delete must be specified');
+
+            return self::FAILURE;
+        }
+
+        try {
+            $this->apiClient->deleteDefinition($type);
+        } catch (Throwable $error) {
+            $style->error(sprintf('Failed to delete the type: %s', $error->getMessage()));
+
+            return self::FAILURE;
+        }
+
+        $style->success(sprintf(
+            'Document type "%s" deleted successfully',
+            $type,
+        ));
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/DeleteSliceCommand.php
+++ b/src/Console/DeleteSliceCommand.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primo\Cli\Console;
+
+use Prismic\DocumentType\SharedSliceManagementClient;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+use function is_string;
+
+#[AsCommand('primo:slices:delete')]
+final class DeleteSliceCommand extends Command
+{
+    public const DEFAULT_NAME = 'primo:slices:delete';
+
+    public function __construct(
+        private SharedSliceManagementClient $apiClient,
+        string $name = self::DEFAULT_NAME,
+    ) {
+        parent::__construct($name);
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription(
+            'This command deletes the specified shared slice',
+        );
+
+        $this->addArgument(
+            'id',
+            InputArgument::REQUIRED,
+            'The slice id to delete',
+        );
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $style = new SymfonyStyle($input, $output);
+        $id = $input->getArgument('id');
+        if (! is_string($id) || $id === '') {
+            $style->error('The id argument is required');
+
+            return self::FAILURE;
+        }
+
+        $this->apiClient->deleteSharedSlice($id);
+        $style->success('Shared slice deleted successfully');
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/DownloadSlicesCommand.php
+++ b/src/Console/DownloadSlicesCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primo\Cli\Console;
+
+use Primo\Cli\Assert;
+use Primo\Cli\Exception\PersistenceError;
+use Primo\Cli\Slice\SlicePersistence;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+use function is_string;
+use function sprintf;
+
+#[AsCommand('primo:slices:download')]
+final class DownloadSlicesCommand extends Command
+{
+    public const DEFAULT_NAME = 'primo:slices:download';
+
+    public function __construct(
+        private readonly SlicePersistence $local,
+        private readonly SlicePersistence $remote,
+        string $name = self::DEFAULT_NAME,
+    ) {
+        parent::__construct($name);
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Download one or all of your shared slice definitions');
+        $this->addArgument('id', InputArgument::OPTIONAL, 'An individual identifier to download', null);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $style = new SymfonyStyle($input, $output);
+
+        $id = $input->getArgument('id');
+        Assert::nullOrStringNotEmpty($id);
+
+        try {
+            $slices = is_string($id)
+                ? [$this->remote->read($id)]
+                : $this->remote->all();
+        } catch (PersistenceError) {
+            $style->error('Failed to read remote slices');
+
+            return self::FAILURE;
+        }
+
+        foreach ($slices as $slice) {
+            $style->comment(sprintf('Downloading "%s"', $slice->id));
+            try {
+                $this->local->write($slice);
+            } catch (PersistenceError) {
+                $style->error(sprintf('Download of "%s" failed', $slice->id));
+
+                return self::FAILURE;
+            }
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/ListSlicesCommand.php
+++ b/src/Console/ListSlicesCommand.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primo\Cli\Console;
+
+use Prismic\DocumentType\SharedSlice;
+use Prismic\DocumentType\SharedSliceManagementClient;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Traversable;
+
+use function array_map;
+use function assert;
+use function count;
+use function is_array;
+use function is_string;
+use function iterator_to_array;
+use function json_decode;
+use function sprintf;
+
+#[AsCommand('primo:slices:list')]
+final class ListSlicesCommand extends Command
+{
+    public const DEFAULT_NAME = 'primo:slices:list';
+
+    public function __construct(
+        private SharedSliceManagementClient $apiClient,
+        string $name = self::DEFAULT_NAME,
+    ) {
+        parent::__construct($name);
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription(
+            'This command lists shared slices. ',
+        );
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $style = new SymfonyStyle($input, $output);
+
+        $slices = $this->apiClient->fetchAllSharedSlices();
+        $slices = $slices instanceof Traversable ? iterator_to_array($slices, false) : $slices;
+
+        $formatSlice = static function (SharedSlice $slice): array {
+            $payload = json_decode($slice->json, true);
+            assert(is_array($payload));
+            $name = $payload['name'] ?? '';
+            assert(is_string($name));
+            $description = $payload['description'] ?? '';
+            assert(is_string($description));
+            $variations = $payload['variations'] ?? [];
+            assert(is_array($variations));
+
+            return [
+                $slice->id,
+                $name,
+                $description,
+                count($variations),
+            ];
+        };
+
+        $style->title(sprintf('Found %d shared slices', count($slices)));
+        $style->table(
+            ['ID', 'Name', 'Description', 'Variations'],
+            array_map($formatSlice, $slices),
+        );
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/UploadSlicesCommand.php
+++ b/src/Console/UploadSlicesCommand.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primo\Cli\Console;
+
+use Primo\Cli\Assert;
+use Primo\Cli\Exception\PersistenceError;
+use Primo\Cli\Slice\SlicePersistence;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+use function is_string;
+use function sprintf;
+
+use const PHP_EOL;
+
+#[AsCommand('primo:slices:upload')]
+final class UploadSlicesCommand extends Command
+{
+    public const DEFAULT_NAME = 'primo:slices:upload';
+
+    public function __construct(
+        private readonly SlicePersistence $local,
+        private readonly SlicePersistence $remote,
+        string $name = self::DEFAULT_NAME,
+    ) {
+        parent::__construct($name);
+    }
+
+    protected function configure(): void
+    {
+        $this->setDescription('Upload one or all shared slice definitions');
+        $this->setHelp(
+            'This command iterates over all your shared slices and uploads them to the remote ' .
+            'custom types api endpoint, making them immediately usable in your Prismic repository.' . PHP_EOL .
+            'You can optionally provide a single identifier to upload just one of the configured slices.',
+        );
+
+        $this->addArgument('id', InputArgument::OPTIONAL, 'An individual identifier to upload', null);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $style = new SymfonyStyle($input, $output);
+
+        $id = $input->getArgument('id');
+        Assert::nullOrStringNotEmpty($id);
+
+        try {
+            $slices = is_string($id)
+                ? [$this->local->read($id)]
+                : $this->local->all();
+        } catch (PersistenceError) {
+            $style->error('Failed to read local slices - make sure they have been built first');
+
+            return self::FAILURE;
+        }
+
+        foreach ($slices as $slice) {
+            $style->comment(sprintf('Uploading "%s"', $slice->id));
+            try {
+                $this->remote->write($slice);
+            } catch (PersistenceError) {
+                $style->error(sprintf('Upload of "%s" failed', $slice->id));
+
+                return self::FAILURE;
+            }
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/CustomTypeApiConfigProvider.php
+++ b/src/CustomTypeApiConfigProvider.php
@@ -35,9 +35,16 @@ final class CustomTypeApiConfigProvider
             'factories' => [
                 Prismic\DocumentType\BaseClient::class => Container\CustomTypeClientFactory::class,
 
+                Console\DeleteCommand::class => Console\Container\DeleteCommandFactory::class,
+                Console\DeleteSliceCommand::class => Console\Container\DeleteSliceCommandFactory::class,
                 Console\DiffCommand::class => Console\Container\DiffCommandFactory::class,
                 Console\DownloadCommand::class => Console\Container\DownloadCommandFactory::class,
+                Console\DownloadSlicesCommand::class => Console\Container\DownloadSlicesCommandFactory::class,
+                Console\ListSlicesCommand::class => Console\Container\ListSlicesCommandFactory::class,
                 Console\UploadCommand::class => Console\Container\UploadCommandFactory::class,
+                Console\UploadSlicesCommand::class => Console\Container\UploadSlicesCommandFactory::class,
+
+                Slice\RemotePersistence::class => Slice\Container\RemotePersistenceFactory::class,
 
                 Type\RemotePersistence::class => Type\Container\RemotePersistenceFactory::class,
 
@@ -53,9 +60,14 @@ final class CustomTypeApiConfigProvider
     private function commands(): array
     {
         return [
+            Console\DeleteCommand::DEFAULT_NAME => Console\DeleteCommand::class,
+            Console\DeleteSliceCommand::DEFAULT_NAME => Console\DeleteSliceCommand::class,
             Console\DiffCommand::DEFAULT_NAME => Console\DiffCommand::class,
             Console\DownloadCommand::DEFAULT_NAME => Console\DownloadCommand::class,
+            Console\DownloadSlicesCommand::DEFAULT_NAME => Console\DownloadSlicesCommand::class,
+            Console\ListSlicesCommand::DEFAULT_NAME => Console\ListSlicesCommand::class,
             Console\UploadCommand::DEFAULT_NAME => Console\UploadCommand::class,
+            Console\UploadSlicesCommand::DEFAULT_NAME => Console\UploadSlicesCommand::class,
         ];
     }
 }

--- a/src/Exception/BuildError.php
+++ b/src/Exception/BuildError.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Primo\Cli\Exception;
 
+use Primo\Cli\Slice\BuildSpec;
 use Primo\Cli\Type\Spec;
 use RuntimeException;
 use Throwable;
@@ -26,6 +27,15 @@ final class BuildError extends RuntimeException
             'The source file for "%s" did not return an array suitable for serialisation. Path: %s',
             $type->name(),
             $source,
+        ));
+    }
+
+    public static function invalidSliceSpec(BuildSpec $spec): self
+    {
+        return new self(sprintf(
+            'The source file for the shared slice "%s" did not return an array suitable for serialisation. Path: %s',
+            $spec->id,
+            $spec->source,
         ));
     }
 }

--- a/src/Slice/BuildSpec.php
+++ b/src/Slice/BuildSpec.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primo\Cli\Slice;
+
+final class BuildSpec
+{
+    /**
+     * @param non-empty-string $source
+     * @param non-empty-string $id
+     */
+    public function __construct(
+        public readonly string $source,
+        public readonly string $id,
+    ) {
+    }
+}

--- a/src/Slice/Container/LocalPersistenceFactory.php
+++ b/src/Slice/Container/LocalPersistenceFactory.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primo\Cli\Slice\Container;
+
+use Primo\Cli\Slice\LocalPersistence;
+use Primo\Cli\Slice\SliceBuildConfig;
+use Psr\Container\ContainerInterface;
+
+final class LocalPersistenceFactory
+{
+    public function __invoke(ContainerInterface $container): LocalPersistence
+    {
+        return new LocalPersistence($container->get(SliceBuildConfig::class));
+    }
+}

--- a/src/Slice/Container/RemotePersistenceFactory.php
+++ b/src/Slice/Container/RemotePersistenceFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primo\Cli\Slice\Container;
+
+use Primo\Cli\Slice\RemotePersistence;
+use Prismic\DocumentType\Client;
+use Prismic\DocumentType\SharedSliceManagementClient;
+use Psr\Container\ContainerInterface;
+use RuntimeException;
+
+final class RemotePersistenceFactory
+{
+    public function __invoke(ContainerInterface $container): RemotePersistence
+    {
+        $client = $container->get(Client::class);
+        if (! $client instanceof SharedSliceManagementClient) {
+            throw new RuntimeException('Ensure that the doctype client version is >= 1.5.0');
+        }
+
+        return new RemotePersistence($client);
+    }
+}

--- a/src/Slice/Container/SliceBuildConfigFactory.php
+++ b/src/Slice/Container/SliceBuildConfigFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primo\Cli\Slice\Container;
+
+use Primo\Cli\Assert;
+use Primo\Cli\Slice\SliceBuildConfig;
+use Psr\Container\ContainerInterface;
+
+final class SliceBuildConfigFactory
+{
+    public function __invoke(ContainerInterface $container): SliceBuildConfig
+    {
+        $config = $container->get('config');
+        Assert::isArrayAccessible($config);
+        $primo = $config['primo'] ?? [];
+        Assert::isArrayAccessible($primo);
+        $cli = $primo['cli'] ?? [];
+        Assert::isArrayAccessible($cli);
+
+        $slices = $cli['slices'] ?? [];
+        Assert::isArrayAccessible($slices);
+
+        $source = $slices['source'] ?? null;
+        Assert::stringNotEmpty($source);
+        $dist = $slices['dist'] ?? null;
+        Assert::stringNotEmpty($dist);
+
+        return SliceBuildConfig::withDirectories($source, $dist);
+    }
+}

--- a/src/Slice/LocalPersistence.php
+++ b/src/Slice/LocalPersistence.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primo\Cli\Slice;
+
+use Primo\Cli\Exception\PersistenceError;
+use Prismic\DocumentType\SharedSlice;
+
+use function assert;
+use function closedir;
+use function file_exists;
+use function file_get_contents;
+use function file_put_contents;
+use function is_file;
+use function is_readable;
+use function opendir;
+use function readdir;
+use function sprintf;
+use function str_ends_with;
+use function substr;
+
+use const DIRECTORY_SEPARATOR;
+
+final class LocalPersistence implements SlicePersistence
+{
+    public function __construct(private readonly SliceBuildConfig $config)
+    {
+    }
+
+    public function has(string $id): bool
+    {
+        return file_exists(sprintf(
+            '%s%s%s.json',
+            $this->config->distDir,
+            DIRECTORY_SEPARATOR,
+            $id,
+        ));
+    }
+
+    public function read(string $id): SharedSlice
+    {
+        if (! $this->has($id)) {
+            throw PersistenceError::readFailure();
+        }
+
+        $data = file_get_contents(sprintf(
+            '%s%s%s.json',
+            $this->config->distDir,
+            DIRECTORY_SEPARATOR,
+            $id,
+        ));
+
+        assert($data !== '');
+
+        return SharedSlice::new($id, $data);
+    }
+
+    public function write(SharedSlice $definition): void
+    {
+        file_put_contents(sprintf(
+            '%s%s%s.json',
+            $this->config->distDir,
+            DIRECTORY_SEPARATOR,
+            $definition->id,
+        ), $definition->json);
+    }
+
+    /** @inheritDoc */
+    public function all(): iterable
+    {
+        $list = [];
+        $handle = opendir($this->config->distDir);
+        while (($filename = readdir($handle)) !== false) {
+            $path = sprintf('%s%s%s', $this->config->distDir, DIRECTORY_SEPARATOR, $filename);
+            if (! is_file($path) || ! is_readable($path)) {
+                continue;
+            }
+
+            if (! str_ends_with($filename, '.json')) {
+                continue;
+            }
+
+            $id = substr($filename, 0, -5);
+            assert($id !== '');
+
+            $list[] = $this->read($id);
+        }
+
+        closedir($handle);
+
+        return $list;
+    }
+}

--- a/src/Slice/RemotePersistence.php
+++ b/src/Slice/RemotePersistence.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primo\Cli\Slice;
+
+use Primo\Cli\Exception\PersistenceError;
+use Prismic\DocumentType\Exception\DefinitionNotFound;
+use Prismic\DocumentType\Exception\Exception;
+use Prismic\DocumentType\SharedSlice;
+use Prismic\DocumentType\SharedSliceManagementClient;
+use Throwable;
+
+final class RemotePersistence implements SlicePersistence
+{
+    public function __construct(private readonly SharedSliceManagementClient $client)
+    {
+    }
+
+    public function has(string $id): bool
+    {
+        try {
+            $this->client->getSharedSlice($id);
+
+            return true;
+        } catch (DefinitionNotFound) {
+            return false;
+        } catch (Exception $error) {
+            throw PersistenceError::readFailure($error);
+        }
+    }
+
+    public function read(string $id): SharedSlice
+    {
+        try {
+            return $this->client->getSharedSlice($id);
+        } catch (Exception $error) {
+            throw PersistenceError::readFailure($error);
+        }
+    }
+
+    public function write(SharedSlice $definition): void
+    {
+        try {
+            $this->client->saveSharedSlice($definition);
+        } catch (Exception $error) {
+            throw PersistenceError::writeFailure($error);
+        }
+    }
+
+    /** @inheritDoc */
+    public function all(): iterable
+    {
+        try {
+            return $this->client->fetchAllSharedSlices();
+        } catch (Throwable $error) {
+            throw PersistenceError::readFailure($error);
+        }
+    }
+}

--- a/src/Slice/SliceBuildConfig.php
+++ b/src/Slice/SliceBuildConfig.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primo\Cli\Slice;
+
+use Primo\Cli\Exception\FilesystemError;
+
+use function assert;
+use function closedir;
+use function is_dir;
+use function is_file;
+use function is_readable;
+use function is_writable;
+use function opendir;
+use function readdir;
+use function rtrim;
+use function sprintf;
+use function str_ends_with;
+use function substr;
+
+use const DIRECTORY_SEPARATOR;
+
+final class SliceBuildConfig
+{
+    /**
+     * @param non-empty-string $sourceDir
+     * @param non-empty-string $distDir
+     */
+    private function __construct(
+        public readonly string $sourceDir,
+        public readonly string $distDir,
+    ) {
+    }
+
+    /**
+     * @param non-empty-string $source
+     * @param non-empty-string $dist
+     */
+    public static function withDirectories(
+        string $source,
+        string $dist,
+    ): self {
+        $source = rtrim($source, DIRECTORY_SEPARATOR);
+        if (! is_dir($source) || $source === '') {
+            throw FilesystemError::missingDirectory($source);
+        }
+
+        if (! is_readable($source)) {
+            throw FilesystemError::notReadable($source);
+        }
+
+        $dist = rtrim($dist, DIRECTORY_SEPARATOR);
+        if (! is_dir($dist) || $dist === '') {
+            throw FilesystemError::missingDirectory($dist);
+        }
+
+        if (! is_writable($dist)) {
+            throw FilesystemError::notWritable($dist);
+        }
+
+        return new self($source, $dist);
+    }
+
+    /** @return list<BuildSpec> */
+    public function slices(): array
+    {
+        $list = [];
+
+        $handle = opendir($this->sourceDir);
+
+        while (($filename = readdir($handle)) !== false) {
+            $path = sprintf(
+                '%s%s%s',
+                $this->sourceDir,
+                DIRECTORY_SEPARATOR,
+                $filename,
+            );
+
+            if (! is_file($path) || ! is_readable($path)) {
+                continue;
+            }
+
+            if (! str_ends_with($filename, '.php')) {
+                continue;
+            }
+
+            $id = substr($filename, 0, -4);
+            assert($id !== '');
+
+            $list[] = new BuildSpec($path, $id);
+        }
+
+        closedir($handle);
+
+        return $list;
+    }
+}

--- a/src/Slice/SlicePersistence.php
+++ b/src/Slice/SlicePersistence.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Primo\Cli\Slice;
+
+use Primo\Cli\Exception\PersistenceError;
+use Prismic\DocumentType\SharedSlice;
+
+interface SlicePersistence
+{
+    /**
+     * Whether the slice is currently persisted
+     *
+     * @param non-empty-string $id
+     *
+     * @throws PersistenceError if a problem occurs querying the underlying storage.
+     */
+    public function has(string $id): bool;
+
+    /**
+     * Retrieve the slice definition by its id
+     *
+     * @param non-empty-string $id
+     *
+     * @throws PersistenceError if a problem occurs reading from the underlying storage.
+     */
+    public function read(string $id): SharedSlice;
+
+    /**
+     * Write the slice definition to storage
+     *
+     * @throws PersistenceError if a problem occurs writing to the underlying storage.
+     */
+    public function write(SharedSlice $definition): void;
+
+    /**
+     * Retrieve a list of known shared slices
+     *
+     * @return iterable<SharedSlice>
+     *
+     * @throws PersistenceError if a problem occurs reading from the underlying storage.
+     */
+    public function all(): iterable;
+}

--- a/src/TypeBuilder.php
+++ b/src/TypeBuilder.php
@@ -26,6 +26,7 @@ final class TypeBuilder
     public const TYPE_RANGE = 'Range';
     public const TYPE_RICH = 'StructuredText';
     public const TYPE_SLICE = 'Slice';
+    public const TYPE_SHARED_SLICE = 'SharedSlice';
     public const TYPE_SLICE_ZONE = 'Slices';
 
     public const P     = 'paragraph';
@@ -454,6 +455,68 @@ final class TypeBuilder
             'non-repeat' => $nonRepeatFields === [] ? null : $nonRepeatFields,
             'repeat' => $repeatFields === [] ? null : $repeatFields,
         ]);
+    }
+
+    /**
+     * @param non-empty-string           $id          Required, non-empty
+     * @param non-empty-string           $name        Required, non-empty
+     * @param string|null                $description Can be null and omitted entirely
+     * @param list<array<string, mixed>> $variations  Must be a list of maps in variation format
+     *
+     * @return array<string, mixed>
+     */
+    public static function sharedSlice(
+        string $id,
+        string $name,
+        string|null $description,
+        array $variations,
+    ): array {
+        Assert::notEmpty($variations);
+
+        return array_filter([
+            'id' => $id,
+            'type' => self::TYPE_SHARED_SLICE,
+            'name' => $name,
+            'description' => $description,
+            'variations' => $variations,
+        ], static fn (mixed $value): bool => $value !== null);
+    }
+
+    /**
+     * @param non-empty-string          $id            Required, non-empty
+     * @param non-empty-string          $name          Required, non-empty
+     * @param non-empty-string          $version       Required, Can actually be empty
+     * @param string                    $description   Required, Can be an empty string
+     * @param array<string, mixed>|null $primaryFields Strangely, not actually required
+     * @param array<string, mixed>|null $repeatFields  Strangely, not actually required
+     * @param non-empty-string|null     $imageUrl      Absolute URL to an image. Can be omitted
+     * @param string                    $docURL        Required, no idea what it is for, can be empty
+     *
+     * @return array<string, mixed>
+     */
+    public static function sharedSliceVariation(
+        string $id,
+        string $name,
+        string $version,
+        string $description = '',
+        array|null $primaryFields = null,
+        array|null $repeatFields = null,
+        string|null $imageUrl = null,
+        string $docURL = '',
+    ): array {
+        $primaryFields = $primaryFields === [] ? null : $primaryFields;
+        $repeatFields = $repeatFields === [] ? null : $repeatFields;
+
+        return array_filter([
+            'id' => $id,
+            'name' => $name,
+            'description' => $description,
+            'docURL' => $docURL,
+            'version' => $version,
+            'primary' => $primaryFields,
+            'items' => $repeatFields,
+            'imageUrl' => $imageUrl,
+        ], static fn (mixed $value): bool => $value !== null);
     }
 
     /** @return array{name: string, display: string} */

--- a/test/Integration/BuildExamplesTest.php
+++ b/test/Integration/BuildExamplesTest.php
@@ -7,6 +7,8 @@ namespace PrimoTest\Cli\Integration;
 use PHPUnit\Framework\TestCase;
 use Primo\Cli\BuildConfig;
 use Primo\Cli\Console\BuildCommand;
+use Primo\Cli\Slice\LocalPersistence as SlicePersistence;
+use Primo\Cli\Slice\SliceBuildConfig;
 use Primo\Cli\Type\LocalPersistence;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\ArgvInput;
@@ -41,8 +43,18 @@ final class BuildExamplesTest extends TestCase
             self::$types,
         );
 
+        $sliceConfig = SliceBuildConfig::withDirectories(
+            __DIR__ . '/../../example/slices/source',
+            __DIR__ . '/../../example/slices/dist',
+        );
+
         $application = new Application('Type Builder Example');
-        $application->add(new BuildCommand($config, new LocalPersistence($config)));
+        $application->add(new BuildCommand(
+            $config,
+            new LocalPersistence($config),
+            $sliceConfig,
+            new SlicePersistence($sliceConfig),
+        ));
         $application->setAutoExit(false);
         $application->setDefaultCommand(BuildCommand::DEFAULT_NAME, true);
         $application->run(new ArgvInput(['', '-qn']));

--- a/test/Integration/ServiceManagerIntegrationTest.php
+++ b/test/Integration/ServiceManagerIntegrationTest.php
@@ -39,6 +39,10 @@ final class ServiceManagerIntegrationTest extends TestCase
                         'source' => __DIR__ . '/../Unit/build-specs/src',
                         'dist' => __DIR__ . '/../Unit/build-specs/dist',
                     ],
+                    'slices' => [
+                        'source' => __DIR__ . '/../Unit/slice-spec/src',
+                        'dist' => __DIR__ . '/../Unit/slice-spec/dist',
+                    ],
                 ],
                 'types' => [
                     [

--- a/test/Unit/TypeBuilderTest.php
+++ b/test/Unit/TypeBuilderTest.php
@@ -130,4 +130,31 @@ class TypeBuilderTest extends TestCase
         /** @psalm-suppress InvalidArgument */
         T::range('Foo', null, 0, 20, 0);
     }
+
+    public function testSharedSliceHasRequiredProperties(): void
+    {
+        $slice = T::sharedSlice(
+            'foo',
+            'bar',
+            '',
+            [
+                T::sharedSliceVariation('foo', 'bar', 'baz', ''),
+            ],
+        );
+
+        $keys = ['id', 'name', 'description', 'variations'];
+
+        foreach ($keys as $key) {
+            self::assertArrayHasKey($key, $slice);
+        }
+    }
+
+    public function testVariationsHaveRequiredKeys(): void
+    {
+        $variation = T::sharedSliceVariation('foo', 'bar', 'baz', '');
+        $keys = ['id', 'name', 'version', 'docURL', 'description'];
+        foreach ($keys as $key) {
+            self::assertArrayHasKey($key, $variation);
+        }
+    }
 }

--- a/test/Unit/slice-spec/src/example.php
+++ b/test/Unit/slice-spec/src/example.php
@@ -1,0 +1,5 @@
+<?php
+
+declare(strict_types=1);
+
+return ['something' => 'foo'];


### PR DESCRIPTION
- New methods on TypeBuilder for help defining shared slices
- Build Shared Slices along with document types
- Download existing shared slices
- Upload new or changed shared slices
- List known (remote) slices
- Delete shared slices
- Delete custom types (Closes #5)